### PR TITLE
LuaJIT: record calls to blacklisted functions uniformly

### DIFF
--- a/lib/luajit/src/lj_record.c
+++ b/lib/luajit/src/lj_record.c
@@ -2411,8 +2411,6 @@ void lj_record_ins(jit_State *J)
   case BC_IFORL:
   case BC_IITERL:
   case BC_ILOOP:
-  case BC_IFUNCF:
-  case BC_IFUNCV:
     lj_trace_err(J, LJ_TRERR_BLACKL);
     break;
 
@@ -2424,6 +2422,7 @@ void lj_record_ins(jit_State *J)
   /* -- Function headers -------------------------------------------------- */
 
   case BC_FUNCF:
+  case BC_IFUNCF:
     rec_func_lua(J);
     break;
   case BC_JFUNCF:
@@ -2431,6 +2430,7 @@ void lj_record_ins(jit_State *J)
     break;
 
   case BC_FUNCV:
+  case BC_IFUNCV:
     rec_func_vararg(J);
     rec_func_lua(J);
     break;


### PR DESCRIPTION
Between https://github.com/inters/vita/compare/c862bbb...dd7bd88 a performance regression had slipped in. This was frustrating because the changes where really negligible with regards to the the data plane: the change caused a central function to be sometimes blacklisted, which impacted the performance of otehr unrelated traces. This change to the LuaJIT VM fixes the regression (and many more like it) by not recording blacklisted bytecodes differently, as can be seen in this Hydra report:

https://hydra.snabb.co/build/2790372/download/2/report.html

![report](https://user-images.githubusercontent.com/4933566/34531840-0f44035c-f0b4-11e7-8b29-360e5c4438de.png)

Cc @lukego