### PR TITLE
Route inbound packets via SPI

### DIFF
--- a/lib/luajit/src/lj_record.c
+++ b/lib/luajit/src/lj_record.c
@@ -2411,8 +2411,6 @@ void lj_record_ins(jit_State *J)
   case BC_IFORL:
   case BC_IITERL:
   case BC_ILOOP:
-  case BC_IFUNCF:
-  case BC_IFUNCV:
     lj_trace_err(J, LJ_TRERR_BLACKL);
     break;
 
@@ -2424,6 +2422,7 @@ void lj_record_ins(jit_State *J)
   /* -- Function headers -------------------------------------------------- */
 
   case BC_FUNCF:
+  case BC_IFUNCF:
     rec_func_lua(J);
     break;
   case BC_JFUNCF:
@@ -2431,6 +2430,7 @@ void lj_record_ins(jit_State *J)
     break;
 
   case BC_FUNCV:
+  case BC_IFUNCV:
     rec_func_vararg(J);
     rec_func_lua(J);
     break;

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -188,15 +188,13 @@ function decrypt:new (conf)
 end
 
 function decrypt:decrypt_payload (ptr, length)
-   if not self.esp:new_from_mem(ptr, length)
-      or self.esp:spi() ~= self.spi
-   then return nil end
-
+   -- NB: bounds check is performed by caller
+   local esp = self.esp:new_from_mem(ptr, esp:sizeof())
    local iv_start = ptr + ESP_SIZE
    local ctext_start = ptr + self.CTEXT_OFFSET
    local ctext_length = length - self.PLAIN_OVERHEAD
 
-   local seq_low = self.esp:seq_no()
+   local seq_low = esp:seq_no()
    local seq_high = tonumber(
       C.check_seq_no(seq_low, self.seq.no, self.window, self.window_size)
    )

--- a/src/program/vita/README.config
+++ b/src/program/vita/README.config
@@ -23,6 +23,7 @@ CONFIGURATION SYNTAX
     net_cidr4 <ipv4prefix>;
     gw_ip4 <ipv4addr>;
     preshared_key <string>;
+    spi <spi>;
 
 NOTES
 
@@ -40,15 +41,19 @@ NOTES
   configure an Ethernet address.
 
   Each route is given a human readable identifier that can be used for
-  documentation purposes. This identifier has no other bearing. The destination
-  IPv4 subnet and gateway are specified with an IPv4 prefix in CIDR notation,
-  and an IPv4 address respectively. Finally, each route is assigned a unique,
-  preshared 256-bit key, encoded as a hexadecimal string (two digits for each
-  octet, most significant digit first).
+  documentation purposes. This identifier has no other bearing. The route’s
+  destination IPv4 subnet and gateway are specified with an IPv4 prefix in CIDR
+  notation, and an IPv4 address respectively. For authentication, each route is
+  assigned a unique, pre-shared 256-bit key, encoded as a hexadecimal string
+  (two digits for each octet, most significant digit first). Finally, a unique
+  Security Parameter Index (SPI), which must be a positive integer equal or
+  greater than 256, is specified for tagging and associating encrypted traffic
+  for a given route. Like the pre-shared key, the SPI must be the same for both
+  ends of a route.
 
-  While the default configuration should be generally applicable, negotiation
-  timeout and the lifetime of security associations can be specified in
-  seconds.
+  While the default configuration should be generally applicable, the
+  negotiation timeout and lifetime of Security Associations (SA) can be
+  specified in seconds.
 
 EXAMPLE
 
@@ -66,6 +71,7 @@ EXAMPLE
     net_cidr4 192.168.20.0/24;
     gw_ip4 203.0.113.2;
     preshared_key 91440DA06376A668AC4959A840A125D75FB544E8AA25A08B813E49F0A4B2E270;
+    spi 1001;
   }
 
   route {
@@ -73,6 +79,7 @@ EXAMPLE
     net_cidr4 192.168.30.0/24;
     gw_ip4 203.0.113.3;
     preshared_key CF0BDD7A058BE55C12B7F2AA30D23FF01BDF8BE6571F2019ED7F7EBD3DA97B47;
+    spi 1002;
   }
 
   sa_ttl 86400;

--- a/src/program/vita/conftest.snabb
+++ b/src/program/vita/conftest.snabb
@@ -47,7 +47,8 @@ local conf1 = {
       loopback = {
          net_cidr4 = "192.168.10.0/24",
          gw_ip4 = "203.0.113.1",
-         preshared_key = string.rep("00", 32)
+         preshared_key = string.rep("00", 32),
+         spi = 1001
       }
    }
 }
@@ -70,7 +71,8 @@ local conf2 = {
       loopback = {
          net_cidr4 = "192.168.10.0/24",
          gw_ip4 = "203.0.113.1",
-         preshared_key = string.rep("FF", 32)
+         preshared_key = string.rep("FF", 32),
+         spi = 1001
       }
    }
 }
@@ -89,7 +91,8 @@ local conf3 = {
       loopback = {
          net_cidr4 = "192.168.10.0/24",
          gw_ip4 = "203.0.113.2",
-         preshared_key = string.rep("FF", 32)
+         preshared_key = string.rep("FF", 32),
+         spi = 1001
       }
    }
 }
@@ -106,14 +109,35 @@ local conf4 = {
    public_nexthop_ip4 = "203.0.113.2",
    route = {
       loopback = {
-         net_cidr4 = "192.168.10.0/24",
+         net_cidr4 = "192.168.10.0/16",
          gw_ip4 = "203.0.113.2",
-         preshared_key = string.rep("FF", 32)
+         preshared_key = string.rep("FF", 32),
+         spi = 1001
       }
    }
 }
-print("Change route public_ip4...")
+print("Change public_ip4 and route net_cidr4...")
 commit_conf(conf4)
+S.sleep(3)
+
+local conf5 = {
+   private_interface = { macaddr = "52:54:00:00:00:00" },
+   public_interface = { macaddr = "52:54:00:00:00:FF" },
+   private_ip4 = "192.168.10.1",
+   public_ip4 = "203.0.113.2",
+   private_nexthop_ip4 = "192.168.10.1",
+   public_nexthop_ip4 = "203.0.113.2",
+   route = {
+      loopback2 = {
+         net_cidr4 = "192.168.10.0/16",
+         gw_ip4 = "203.0.113.2",
+         preshared_key = string.rep("FF", 32),
+         spi = 1001
+      }
+   }
+}
+print("Change route id...")
+commit_conf(conf5)
 S.sleep(3)
 
 print("Remove route...")

--- a/src/program/vita/schemata.lua
+++ b/src/program/vita/schemata.lua
@@ -7,8 +7,8 @@ module(...,package.seeall)
 local yang = require("lib.yang.yang")
 
 return {
-   ['esp-gateway'] =
-      yang.load_schema_by_name('vita-esp-gateway', nil, "program.vita"),
    ['ephemeral-keys'] =
-      yang.load_schema_by_name('vita-ephemeral-keys', nil, "program.vita")
+      yang.load_schema_by_name('vita-ephemeral-keys', nil, "program.vita"),
+   ['esp-gateway'] =
+      yang.load_schema_by_name('vita-esp-gateway', nil, "program.vita")
 }

--- a/src/program/vita/test.snabb
+++ b/src/program/vita/test.snabb
@@ -53,7 +53,8 @@ local conf = {
       loopback = {
          net_cidr4 = "192.168.10.0/24",
          gw_ip4 = "203.0.113.1",
-         preshared_key = string.rep("00", 32)
+         preshared_key = string.rep("00", 32),
+         spi = 1000
       }
    },
    negotiation_ttl = 1

--- a/src/program/vita/vita-ephemeral-keys.yang
+++ b/src/program/vita/vita-ephemeral-keys.yang
@@ -2,21 +2,16 @@ module vita-ephemeral-keys {
   namespace vita:ephemeral-keys;
   prefix ephemeral-keys;
 
-  import ietf-inet-types { prefix inet; }
-
+  typedef spi { type uint32 { range "256..max"; } }
   typedef key16 { type string { patttern '([0-9a-fA-F]{2}\s*){16}'; } }
   typedef key4  { type string { patttern '([0-9a-fA-F]{2}\s*){4}'; } }
 
-  list route {
-    key id; unique "gw_ip4";
+  list sa {
+    key id; unique "spi key";
     leaf id { type string; mandatory true; }
-    leaf gw_ip4 { type inet:ipv4-address-no-zone; mandatory true; }
-    container sa {
-      presence "Present if a SA was negotiated.";
-      leaf mode { type string; mandatory true; }
-      leaf spi { type uint32 { range "1..max"; } mandatory true; }
-      leaf key { type key16; mandatory true; }
-      leaf salt { type key4; mandatory true; }
-    }
+    leaf mode { type string; mandatory true; }
+    leaf spi { type spi; mandatory true; }
+    leaf key { type key16; mandatory true; }
+    leaf salt { type key4; mandatory true; }
   }
 }

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -4,6 +4,7 @@ module vita-esp-gateway {
 
   import ietf-yang-types { prefix yang; }
   import ietf-inet-types { prefix inet; }
+  import vita-ephemeral-keys { prefix ephemeral-keys; }
 
   typedef pci-address {
     type string {
@@ -31,11 +32,12 @@ module vita-esp-gateway {
   leaf public_nexthop_ip4 { type inet:ipv4-address-no-zone; mandatory true; }
 
   list route {
-    key id; unique "gw_ip4 net_cidr4";
+    key id; unique "net_cidr4 preshared_key spi";
     leaf id { type string; mandatory true; }
     leaf net_cidr4 { type inet:ipv4-prefix; mandatory true; }
     leaf gw_ip4 { type inet:ipv4-address-no-zone; mandatory true; }
     leaf preshared_key { type key32; mandatory true; }
+    leaf spi { type ephemeral-keys:spi; mandatory true; }
   }
 
   leaf negotiation_ttl { type time-to-live; }

--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -113,13 +113,13 @@ function configure_private_router (conf, append)
 
    for _, route in pairs(conf.route) do
       local private_in = "PrivateRouter."..config.link_name(route.net_cidr4)
-      local ESP_in = "ESP_"..config.link_name(route.gw_ip4).."_in"
+      local ESP_in = "ESP_"..route.spi.."_in"
       config.app(c, ESP_in, Transmitter,
                  {name="group/interlink/"..ESP_in, create=true})
       config.link(c, private_in.." -> "..ESP_in..".input")
 
       local private_out = "PrivateNextHop."..config.link_name(route.net_cidr4)
-      local DSP_out = "DSP_"..config.link_name(route.gw_ip4).."_out"
+      local DSP_out = "DSP_"..route.spi.."_out"
       config.app(c, DSP_out, Receiver,
                  {name="group/interlink/"..DSP_out, create=true})
       config.link(c, DSP_out..".output -> "..private_out)
@@ -159,14 +159,14 @@ function configure_public_router (conf, append)
    config.link(c, "KeyExchange.output -> PublicNextHop.protocol")
 
    for _, route in pairs(conf.route) do
-      local public_in = "PublicRouter."..config.link_name(route.gw_ip4)
-      local DSP_in = "DSP_"..config.link_name(route.gw_ip4).."_in"
+      local public_in = "PublicRouter."..route.spi
+      local DSP_in = "DSP_"..route.spi.."_in"
       config.app(c, DSP_in, Transmitter,
                  {name="group/interlink/"..DSP_in, create=true})
       config.link(c, public_in.." -> "..DSP_in..".input")
 
       local public_out = "PublicNextHop."..config.link_name(route.gw_ip4)
-      local ESP_out = "ESP_"..config.link_name(route.gw_ip4).."_out"
+      local ESP_out = "ESP_"..route.spi.."_out"
       local Tunnel = "Tunnel_"..config.link_name(route.gw_ip4)
       config.app(c, ESP_out, Receiver,
                  {name="group/interlink/"..ESP_out, create=true})
@@ -259,24 +259,22 @@ function public_router_loopback_worker (confpath, cpu, memnode)
 end
 
 
--- ephemeral_keys := { { gw_ip4=(IPv4), [ sa=(SA) ] }, ... }   (see exchange)
+-- ephemeral_keys := { <id>=(SA), ... }                        (see exchange)
 
 function configure_esp (ephemeral_keys)
    local c = config.new()
 
-   for _, route in pairs(ephemeral_keys.route) do
-      -- Configure interlink receiver/transmitter for route
-      local ESP_in = "ESP_"..config.link_name(route.gw_ip4).."_in"
-      local ESP_out = "ESP_"..config.link_name(route.gw_ip4).."_out"
+   for _, sa in pairs(ephemeral_keys.sa) do
+      -- Configure interlink receiver/transmitter for inbound SA
+      local ESP_in = "ESP_"..sa.spi.."_in"
+      local ESP_out = "ESP_"..sa.spi.."_out"
       config.app(c, ESP_in, Receiver, {name="group/interlink/"..ESP_in})
       config.app(c, ESP_out, Transmitter, {name="group/interlink/"..ESP_out})
-      -- Configure SA if present
-      if route.sa then
-         local ESP = "ESP_"..route.sa.spi
-         config.app(c, ESP, tunnel.Encapsulate, route.sa)
-         config.link(c, ESP_in..".output -> "..ESP..".input4")
-         config.link(c, ESP..".output -> "..ESP_out..".input")
-      end
+      -- Configure inbound SA
+      local ESP = "ESP_"..sa.spi
+      config.app(c, ESP, tunnel.Encapsulate, sa)
+      config.link(c, ESP_in..".output -> "..ESP..".input4")
+      config.link(c, ESP..".output -> "..ESP_out..".input")
    end
 
    return c
@@ -285,19 +283,17 @@ end
 function configure_dsp (ephemeral_keys)
    local c = config.new()
 
-   for _, route in pairs(ephemeral_keys.route) do
-      -- Configure interlink receiver/transmitter for route
-      local DSP_in = "DSP_"..config.link_name(route.gw_ip4).."_in"
-      local DSP_out = "DSP_"..config.link_name(route.gw_ip4).."_out"
+   for _, sa in pairs(ephemeral_keys.sa) do
+      -- Configure interlink receiver/transmitter for outbound SA
+      local DSP_in = "DSP_"..sa.spi.."_in"
+      local DSP_out = "DSP_"..sa.spi.."_out"
       config.app(c, DSP_in, Receiver, {name="group/interlink/"..DSP_in})
       config.app(c, DSP_out, Transmitter, {name="group/interlink/"..DSP_out})
-      -- Configure SA if present
-      if route.sa then
-         local DSP = "DSP_"..route.sa.spi
-         config.app(c, DSP, tunnel.Decapsulate, route.sa)
-         config.link(c, DSP_in..".output -> "..DSP..".input")
-         config.link(c, DSP..".output4 -> "..DSP_out..".input")
-      end
+      -- Configure outbound SA
+      local DSP = "DSP_"..sa.spi
+      config.app(c, DSP, tunnel.Decapsulate, sa)
+      config.link(c, DSP_in..".output -> "..DSP..".input")
+      config.link(c, DSP..".output4 -> "..DSP_out..".input")
    end
 
    return c


### PR DESCRIPTION
Previously, Vita treated the Security Parameter Index as an opaque, random, uninteresting additional authentication data. This was nice in the regard that the SPI, which is a somewhat arcane concept, was not relevant when configuring Vita.

This branch promotes the SPI to be used as the sole routing identifier of a route, i.e. paddles back on the former approach. One unique SPI has to be configured per route (and has to match on both ends of the route), and its persistent across different SAs for the given route.

Besides being more true to the spirit of RFC 4301, this change enables future testing with arbitrary numbers of routes using a single Vita node (with a single IP address, which was previously used to route packets).