### PR TITLE
Simulate multiple routes in test cases

### DIFF
--- a/src/Makefile.vita-test
+++ b/src/Makefile.vita-test
@@ -1,4 +1,4 @@
-SRCPATTERN = '\([^/\#\.]*\|\(core/\|arch/\|jit/\|syscall/\|lib/lua/\|lib/protocol/\|lib/checksum\|lib/ipsec/\|lib/yang/\|lib/xsd_regexp\|lib/maxpc\|lib/ctable\|lib/binary_search\|lib/multi_copy\|lib/hash/\|lib/cltable\|lib/lpm/\|lib/interlink\|lib/hardware/\|lib/macaddress\|lib/numa\|apps/basic/\|apps/test/\|apps/packet_filter/\|pf\|apps/pcap/\|lib/pcap/\|apps/interlink/\|apps/intel_mp/\|program/snsh\|program/vita\)[^\#]*\)'
+SRCPATTERN = '\([^/\#\.]*\|\(core/\|arch/\|jit/\|syscall/\|lib/lua/\|lib/protocol/\|lib/checksum\|lib/ipsec/\|lib/yang/\|lib/xsd_regexp\|lib/maxpc\|lib/ctable\|lib/binary_search\|lib/multi_copy\|lib/hash/\|lib/cltable\|lib/lpm/\|lib/interlink\|lib/hardware/\|lib/macaddress\|lib/numa\|apps/basic/\|apps/test/\|apps/packet_filter/\|pf\|apps/pcap/\|lib/pcap/\|apps/interlink/\|apps/intel_mp/\|apps/ipv4\|apps/rate_limiter\|program/snsh\|program/vita\)[^\#]*\)'
 
 all:
 	SRCPATTERN=$(SRCPATTERN) $(MAKE)

--- a/src/program/vita/gentest.lua
+++ b/src/program/vita/gentest.lua
@@ -1,0 +1,86 @@
+-- Use of this source code is governed by the GNU AGPL license; see COPYING.
+
+module(..., package.seeall)
+
+local vita = require("program.vita.vita")
+local ethernet= require("lib.protocol.ethernet")
+local ipv4 = require("lib.protocol.ipv4")
+local datagram = require("lib.protocol.datagram")
+local yang = require("lib.yang.yang")
+local lib = require("core.lib")
+
+-- Test case generation for Vita via synthetic traffic and configurations.
+-- Exposes configuration knobs like “number of routes” and “packet size”.
+--
+-- XXX
+
+defaults = {
+   private_mac = {default="52:54:00:00:00:01"},
+   private_ip4 = {default="192.168.0.1"},
+   private_nexthop_ip4 = {default="192.168.0.2"},
+   public_mac = {default="52:54:00:00:00:FF"},
+   public_ip4 = {default="203.0.113.1"},
+   public_nexthop_ip4 = {default="203.0.113.1"},
+   next_gw_ip4 = {default="203.0.113.1"},
+   route_prefix = {default="172.16"},
+   nroutes = {default=1},
+   packet_size = {default="IMIX"}
+}
+
+traffic_templates = {
+   -- Internet Mix, see https://en.wikipedia.org/wiki/Internet_Mix
+   IMIX = { 54, 54, 54, 54, 54, 54, 54, 590, 590, 590, 590, 1514 }
+}
+
+function gen_packet (conf, route, size)
+   local payload_size = size - ethernet:sizeof() - ipv4:sizeof()
+   assert(payload_size >= 0, "Negative payload_size :-(")
+   local d = datagram:new(packet.resize(packet.allocate(), payload_size))
+   d:push(ipv4:new{ src = ipv4:pton(conf.private_nexthop_ip4),
+                    dst = ipv4:pton(conf.route_prefix.."."..route..".1"),
+                    ttl = 64 })
+   d:push(ethernet:new{ dst = ethernet:pton(conf.private_mac),
+                        type = 0x0800 })
+   return d:packet()
+end
+
+function gen_packets (conf)
+   local sim_packets = {}
+   local sizes = traffic_templates[conf.packet_size] or {conf.packet_size}
+   for _, size in ipairs(sizes) do
+      for route = 1, conf.nroutes do
+         table.insert(sim_packets, gen_packet(conf, route, size))
+      end
+   end
+   return sim_packets
+end
+
+function gen_cfg (conf)
+   local cfg = {
+      private_interface = { pciaddr = "00:00.0", macaddr = conf.private_mac },
+      public_interface = { pciaddr = "00:00.0", macaddr = conf.public_mac },
+      private_ip4 = conf.private_ip4,
+      public_ip4 = conf.public_ip4,
+      private_nexthop_ip4 = conf.private_nexthop_ip4,
+      public_nexthop_ip4 = conf.public_nexthop_ip4,
+      route = {},
+      negotiation_ttl = 1
+   }
+   for route = 1, conf.nroutes do
+      cfg.route["test"..route] = {
+         net_cidr4 = conf.route_prefix.."."..route..".0/24",
+         gw_ip4 = conf.next_gw_ip4,
+         preshared_key = string.rep("00", 32),
+         spi = 1000+route
+      }
+   end
+   return cfg
+end
+
+-- Return test configuration and simulation packets according to conf
+function gen_testcase (conf)
+   conf = lib.parse(conf, defaults)
+   assert(conf.nroutes >= 1 and conf.nroutes <= 255,
+          "Invalid number of routes: "..conf.nroutes)
+   return gen_cfg(conf), gen_packets(conf)
+end

--- a/src/program/vita/realtest.snabb
+++ b/src/program/vita/realtest.snabb
@@ -2,6 +2,7 @@
 
 -- Use of this source code is governed by the GNU AGPL license; see COPYING.
 
+local gentest = require("program.vita.gentest")
 local counter = require("core.counter")
 local Intel = require("apps.intel_mp.intel_mp").Intel
 local ARP = require("apps.ipv4.arp").ARP
@@ -16,10 +17,10 @@ local S = require("syscall")
 
 -- Synopsis:
 --
---    realtest.snabb <pciaddr> <macaddr> <src> <dst> <nh> \
---       [<duration>] [<pktsize>|IMIX] [<gbps>] [<cpu>]
+--    realtest.snabb <pciaddr> <macaddr> <ip> <nh> \
+--       [<duration>] [<pktsize>|IMIX] [<gbps>] [<nroutes>] [<prefix>] [<cpu>]
 --
---     Default is 10 seconds at 10 Gbps IMIX.                               (-:
+--     Default is 10 seconds at 10 Gbps IMIX via one route with prefix 172.16.
 --
 -- This hardware-based benchmarking design for Vita simulates a private
 -- next-hop suitable for evaluating Vita performance in a realistic setting.
@@ -29,8 +30,12 @@ local S = require("syscall")
 --
 --    realtest(A) <-> Vita(A) <-> Vita(B) <-> realtest(B)
 --
--- Subsequently, two interconnected pairs of (possibly virtualized) NIC ports
--- are required to test Vita using two opposing instances of realtest.
+-- ...where <pciaddr>, <macaddr> and <ip> denote realtest(A), <nh> is the
+-- private IP address of Vita(A). Subsequently, three interconnected pairs of
+-- (possibly virtualized) NIC ports are required to test Vita using two
+-- opposing instances of realtest. The Vita node to be tested must be
+-- configured accordingly for routes <prefix>.N.0/24 with SPI 1000+N with
+-- all-zero keys for N from 1 to <nroutes>.
 --
 -- Here is a diagram of the app graph implemented:
 --
@@ -64,50 +69,33 @@ local S = require("syscall")
 
 local pciaddr = assert(main.parameters[1], "Need pciaddr")
 local macaddr = assert(main.parameters[2], "Need macaddr")
-local src = assert(main.parameters[3], "Need src")
-local dst = assert(main.parameters[4], "Need dst")
-local nh = assert(main.parameters[5], "Need dst")
-local duration = tonumber(main.parameters[6]) or 10
-local pktsize = main.parameters[7] or "IMIX"
-local rate = main.parameters[8] or 10
-if rate then rate = math.floor((tonumber(rate)/8)*1e9) end
-local cpu = tonumber(main.parameters[9])
-
-
-local IMIX = { 54, 54, 54, 54, 54, 54, 54, 590, 590, 590, 590, 1514 }
-
-function test_packets (macaddr, src, dst, pktsize)
-   pktsize = pktsize ~= "IMIX" and tonumber(pktsize)
-   local sizes = (pktsize and {pktsize}) or IMIX
-   local packets = {}
-   for _, size in ipairs(sizes) do
-      local payload_size = size - ethernet:sizeof() - ipv4:sizeof()
-      assert(payload_size >= 0, "Negative payload_size :-(")
-      local d = datagram:new(packet.resize(packet.allocate(), payload_size))
-      d:push(ipv4:new{ src = ipv4:pton(src),
-                       dst = ipv4:pton(dst),
-                       ttl = 64 })
-      d:push(ethernet:new{ src = ethernet:pton(macaddr),
-                           type = 0x0800 })
-      packets[#packets+1] = d:packet()
-   end
-   return packets
-end
-
+local ip = assert(main.parameters[3], "Need ip")
+local nh = assert(main.parameters[4], "Need nh")
+local duration = tonumber(main.parameters[5]) or 10
+local pktsize = tonumber(main.parameters[6]) or main.parameters[6]
+local rate = math.floor(tonumber(main.parameters[7] or 10)*1e9/8)
+local nroutes = tonumber(main.parameters[8])
+local route_prefix = main.parameters[9]
+local cpu = tonumber(main.parameters[10])
 
 numa.bind_to_cpu(cpu)
-
 
 local c = config.new()
 
 config.app(c, "nic", Intel, {pciaddr=pciaddr, macaddr=macaddr, vmdq=true})
 config.app(c, "arp", ARP, {self_mac=ethernet:pton(macaddr),
-                           self_ip=ipv4:pton(src),
+                           self_ip=ipv4:pton(ip),
                            next_ip=ipv4:pton(nh)})
 config.link(c, "nic.output -> arp.south")
 config.link(c, "arp.south -> nic.input")
 
-config.app(c, "synth", Synth, {packets=test_packets(macaddr,src,dst,pktsize)})
+local _, sim_packets = gentest.gen_testcase({
+      private_nexthop_ip4 = ip,
+      route_prefix = route_prefix,
+      nroutes = nroutes,
+      packet_size = pktsize
+})
+config.app(c, "synth", Synth, {packets=sim_packets})
 config.app(c, "rate", RateLimiter, {rate=rate, bucket_capacity=rate})
 config.link(c, "synth.output -> rate.input")
 config.link(c, "rate.output -> arp.north")

--- a/src/program/vita/test.snabb
+++ b/src/program/vita/test.snabb
@@ -7,6 +7,7 @@ local lib = require("core.lib")
 local worker = require("core.worker")
 local counter = require("core.counter")
 local vita = require("program.vita.vita")
+local gentest = require("program.vita.gentest")
 local basic_apps = require("apps.basic.basic_apps")
 local Synth = require("apps.test.synth").Synth
 local PcapFilter = require("apps.packet_filter.pcap_filter").PcapFilter
@@ -19,9 +20,9 @@ local S = require("syscall")
 
 -- Synopsis:
 --
---    sudo program/vita/test.snabb [<pktsize>|IMIX] [<npackets>]
+--    sudo program/vita/test.snabb [<pktsize>|IMIX] [<npackets>] [<nroutes>]
 --
---     Default is 10 million packets at IMIX.                               (-:
+--     Default is 10 million packets at IMIX via one route.                 (-:
 --
 -- This is a software-only benchmark scenario for Vita. It simulates a single
 -- Vita node with the public ports being connected in loop-back mode (i.e.,
@@ -63,45 +64,11 @@ local S = require("syscall")
 --
 -- For a more realistic test case see: realtest.snabb
 
-local IMIX = { 54, 54, 54, 54, 54, 54, 54, 590, 590, 590, 590, 1514 }
-
-function test_packets (pktsize)
-   pktsize = pktsize ~= "IMIX" and tonumber(pktsize)
-   local sizes = (pktsize and {pktsize}) or IMIX
-   local packets = {}
-   for _, size in ipairs(sizes) do
-      local payload_size = size - ethernet:sizeof() - ipv4:sizeof()
-      assert(payload_size >= 0, "Negative payload_size :-(")
-      local d = datagram:new(packet.resize(packet.allocate(), payload_size))
-      d:push(ipv4:new{ src = ipv4:pton("192.168.10.100"),
-                       dst = ipv4:pton("192.168.10.200"),
-                       ttl = 64 })
-      d:push(ethernet:new{ src = ethernet:pton("52:54:00:00:00:00"),
-                           dst = ethernet:pton("52:54:00:00:00:00"),
-                           type = 0x0800 })
-      packets[#packets+1] = d:packet()
-   end
-   return packets
-end
-
-
-local conf = {
-   private_interface = { pciaddr = "00:00.0", macaddr = "52:54:00:00:00:00" },
-   public_interface = { pciaddr = "00:00.0", macaddr = "52:54:00:00:00:FF" },
-   private_ip4 = "192.168.10.1",
-   public_ip4 = "203.0.113.1",
-   private_nexthop_ip4 = "192.168.10.1",
-   public_nexthop_ip4 = "203.0.113.1",
-   route = {
-      loopback = {
-         net_cidr4 = "192.168.10.0/24",
-         gw_ip4 = "203.0.113.1",
-         preshared_key = string.rep("00", 32),
-         spi = 1000
-      }
-   },
-   negotiation_ttl = 1
-}
+local conf, sim_packets = gentest.gen_testcase({
+      private_nexthop_ip4 = gentest.defaults.private_ip4.default,
+      packet_size = tonumber(main.parameters[1]) or main.parameters[1],
+      nroutes = tonumber(main.parameters[3])
+})
 
 local current_node = S.getcpu().node
 vita.cpubind(nil, current_node)
@@ -111,7 +78,7 @@ local c, private = vita.configure_private_router(conf, config.new())
 config.app(c, "bridge", basic_apps.Join)
 config.link(c, "bridge.output -> "..private.input)
 
-config.app(c, "synth", Synth, {packets=test_packets(main.parameters[1])})
+config.app(c, "synth", Synth, {packets=sim_packets})
 config.link(c, "synth.output -> bridge.synth")
 
 config.app(c, "sieve", PcapFilter, {filter="arp"})


### PR DESCRIPTION
This extends `test.snabb` and `realtest.snabb` to simulate up to 255 routes.

Depends on #25 

Resolves #6 