### PR TITLE
vita: change test script shebangs to use snabb exe in cwd

### DIFF
--- a/src/program/vita/realtest.snabb
+++ b/src/program/vita/realtest.snabb
@@ -1,4 +1,4 @@
-#!/usr/bin/env snabb snsh
+#!snabb snsh
 
 -- Use of this source code is governed by the GNU AGPL license; see COPYING.
 

--- a/src/program/vita/test.snabb
+++ b/src/program/vita/test.snabb
@@ -1,4 +1,4 @@
-#!/usr/bin/env snabb snsh
+#!snabb snsh
 
 -- Use of this source code is governed by the GNU AGPL license; see COPYING.
 


### PR DESCRIPTION
A trivial change that I missed earlier. Lets you run the tests via e.g.:

```
$ cd vita
$ make -j
$ cd src
$ program/vita/test.snabb
…
```