### PR TITLE
Update Makefile.vita-test to support more IPsec tests

### DIFF
--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -1,4 +1,4 @@
-SRCPATTERN = '\([^/\#\.]*\|\(core/\|arch/\|jit/\|syscall/\|lib/lua/\|lib/protocol/\|lib/checksum\|lib/ipsec/\|lib/ptree/\|lib/yang/\|lib/xsd_regexp\|lib/maxpc\|lib/ctable\|lib/binary_search\|lib/multi_copy\|lib/hash/\|lib/cltable\|lib/lpm/\|lib/interlink\|lib/hardware/\|lib/macaddress\|lib/numa\|apps/interlink/\|apps/intel_mp/\|lib/sodium\|program/vita\|program/top\|program/trace\|program/ps\|program/pci_bind\)[^\#]*\)'
+SRCPATTERN = '\([^/\#\.]*\|\(core/\|arch/\|jit/\|syscall/\|lib/lua/\|lib/protocol/\|lib/checksum\|lib/ipsec/\|lib/ptree/\|lib/yang/\|lib/xsd_regexp\|lib/maxpc\|lib/ctable\|lib/binary_search\|lib/multi_copy\|lib/hash/\|lib/cltable\|lib/lpm/\|lib/interlink\|lib/hardware/\|lib/macaddress\|lib/numa\|apps/interlink/\|apps/intel_mp/\|program/vita/\|program/top/\|program/trace/\|program/ps/\|program/pci_bind/\)[^\#]*\)'
 
 all:
 	SRCPATTERN=$(SRCPATTERN) $(MAKE)

--- a/src/Makefile.vita-test
+++ b/src/Makefile.vita-test
@@ -1,4 +1,4 @@
-SRCPATTERN = '\([^/\#\.]*\|\(core/\|arch/\|jit/\|syscall/\|lib/lua/\|lib/protocol/\|lib/checksum\|lib/ipsec/\|lib/ptree/\|lib/yang/\|lib/xsd_regexp\|lib/maxpc\|lib/ctable\|lib/binary_search\|lib/multi_copy\|lib/hash/\|lib/cltable\|lib/lpm/\|lib/interlink\|lib/hardware/\|lib/macaddress\|lib/numa\|apps/basic/\|apps/test/\|apps/packet_filter/\|pf\|apps/pcap/\|lib/pcap/\|apps/interlink/\|apps/intel_mp/\|apps/ipv4\|apps/rate_limiter\|program/snsh\|program/vita\)[^\#]*\)'
+SRCPATTERN = '\([^/\#\.]*\|\(core/\|arch/\|jit/\|syscall/\|lib/lua/\|lib/protocol/\|lib/checksum\|lib/ipsec/\|lib/ptree/\|lib/yang/\|lib/xsd_regexp\|lib/maxpc\|lib/ctable\|lib/binary_search\|lib/multi_copy\|lib/hash/\|lib/cltable\|lib/lpm/\|lib/pmu\|lib/interlink\|lib/hardware/\|lib/macaddress\|lib/numa\|apps/basic/\|apps/test/\|apps/packet_filter/\|pf\|apps/pcap/\|lib/pcap/\|apps/interlink/\|apps/intel_mp/\|apps/ipv4/\|apps/rate_limiter/\|apps/ipsec/\|apps/ipv6/\|apps/vhost/\|lib/virtio/\|program/snsh/\|program/snabbmark/\|program/vita/\)[^\#]*\)'
 
 all:
 	SRCPATTERN=$(SRCPATTERN) $(MAKE)


### PR DESCRIPTION
Namely, support running:

 - snabbmark esp
 - apps/ipsec/selftest.sh

Also cleanup SRCPATTERNs along the way.

This somewhat amends #29 and #7.