### PR TITLE
.travis.yml: test multiple routes but only one million packets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
 
 script:
  - make -j
- - (cd src && sudo ./snabb snsh program/vita/test.snabb)
+ - (cd src && sudo ./snabb snsh program/vita/test.snabb IMIX 1e6 3)


### PR DESCRIPTION
 - Test multiple routes for obvious reasons

 - One million packets its probably enough to flush out trivial bugs and takes
   less of a toll on the infrastructure provided for free by Travis CI.