### PR TITLE
vita: hopefully fix a race condition in listen_confpath

### DIFF
--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -354,7 +354,7 @@ function listen_confpath (schema, confpath, loader, interval)
    local needs_reconfigure = true
    local function check_reconfigure ()
       if not conf_fd then
-         conf_fd = notify_fd:inotify_add_watch(confpath, "modify")
+         conf_fd = notify_fd:inotify_add_watch(confpath, "close_write")
          needs_reconfigure = needs_reconfigure or conf_fd
       else
          local n, err = notify_fd:inotify_read()


### PR DESCRIPTION
This addresses a case with the old “check-for-reconfigure” mechanism that was
based on stat/mtime where workers failed to pick up new configurations,
presumably due to the limited resolution of mtimes. This change instead uses
the inotify API via ljsyscall, and hopefully does not suffer the same issue.

(This was somewhat reliably reproducible with delays incurred from setting `SNABB_SHM_ROOT` to a non-ramdisk.)