### PR TITLE
KeyManager: protocol cleanup

### DIFF
--- a/src/program/vita/README.exchange
+++ b/src/program/vita/README.exchange
@@ -1,4 +1,4 @@
-VITA: SIMPLE KEY EXCHANGE (vita-ske, version 1g)
+VITA: SIMPLE KEY EXCHANGE (vita-ske, version 1h)
 
  A simple key negotiation protocol based on pre-shared symmetric keys that
  provides authentication, perfect forward secrecy, and is immune to replay
@@ -8,7 +8,7 @@ Primitives (from libsodium 1.0.15):
 
  • HMAC: crypto_auth_hmacsha512256 (key is 256‑bits, output is 256‑bits)
  • DH: crypto_scalarmult_curve25519 (keys are 256‑bits, output is 256‑bits)
- • HASH: crypto_generichash_blake2b (output is choosen to be 160‑bits)
+ • HASH: crypto_generichash_blake2b (output is choosen to be 128‑bits)
 
 Notational Conventions:
 
@@ -20,6 +20,9 @@ Notational Conventions:
 
  a ‖ b
   Denotes a concatenated with b.
+
+ x:i
+  Denotes the i highest bits of x.
 
 Description:
 
@@ -37,8 +40,9 @@ Description:
 
  Ensure that h2 = HMAC(k, spi ‖ n2 ‖ n1 ‖ p2). Let q = DH(s1, p2), and ensure
  that p2 is a valid argument. Let rx = HASH(q ‖ p1 ‖ p2) and
- tx = HASH(q ‖ p2 ‖ p1) be key material. Assign (spi, rx) to the incoming
- “Security Association” (SA), and (spi, tx) to the outgoing SA.
+ tx = HASH(q ‖ p2 ‖ p1) be key material. Let rxs = n1:32 and txs = n2:32 be
+ salt values. Assign (spi, rx, rxs) to the incoming “Security Association”
+ (SA), and (spi, tx, txs) to the outgoing SA.
 
  The description above illustrates the perspective of an active party adhering
  to the protocol, i.e. the exchange is initiated by us. An opposite, passive
@@ -67,11 +71,17 @@ Security Proof:
  q = DH(s1, p2) or q = DH(s2, p1), and subsequently derive rx or tx, and thus
  perfect forward secrecy is provided.
 
+ Assuming an attacker can not produce h2, and n2 is truly random and hence
+ unpredicable, it is provided that txs =n2:32 is authentic and unpredictable.
+
  A party passively adhering to the protocol will not produce a tuple
  (spi, p1, h1) unless it has previously authenticated its counterpart tuple
  (spi, p2, h2), and thus can not be used as an oracle.
 
 Notes:
+
+ • The outputs of this protocol are choosen specifically to support the AES-GCM
+   algorithm as used in an IPsec ESP data plane.
 
  • Future versions of this protocol may introduce the use of a key derivation
    function (KDF), such as libsodium’s crypto_kdf_blake2b_derive_from_key, to
@@ -81,9 +91,15 @@ References:
 
  • The spiped protocol:
    https://github.com/Tarsnap/spiped/blob/d1e62a8/DESIGN.md#spiped-design
+
  • Additional discussion of the spiped protocol:
    https://github.com/Tarsnap/spiped/issues/151
+
  • The Sodium crypto library (libsodium):
    https://download.libsodium.org/doc/
+
  • Security Architecture for the Internet Protocol:
    https://tools.ietf.org/html/rfc4301
+
+ • The use of AES-GCM in IPsec ESP:
+   https://tools.ietf.org/html/rfc4106

--- a/src/program/vita/exchange.lua
+++ b/src/program/vita/exchange.lua
@@ -108,7 +108,7 @@ module(...,package.seeall)
 --        receive_nonce
 --        exchange_key
 --        receive_key
---        derive_ephemeral_keys
+--        derive_keying_material
 --        reset_if_expired
 --
 --     which uphold invariants that should ensure any resulting key material is
@@ -330,7 +330,7 @@ function KeyManager:handle_key_request (route, message)
       return false
    else assert(not ecode) end
 
-   local ecode, rx, tx = route.protocol:derive_ephemeral_keys()
+   local ecode, rx, tx = route.protocol:derive_keying_material()
    if ecode == Protocol.code.parameter then
       counter.add(self.shm.public_key_errors)
       return false
@@ -457,7 +457,7 @@ function KeyManager:commit_ephemeral_keys ()
    store_ephemeral_keys(self.dsp_keyfile, dsp_keys)
 end
 
--- Vita: simple key exchange (vita-ske, version 1g). See README.exchange
+-- Vita: simple key exchange (vita-ske, version 1f). See README.exchange
 
 Protocol = {
    status = { idle = 0, wait_nonce = 1, wait_key = 2, complete = 3 },
@@ -466,18 +466,11 @@ Protocol = {
    public_key_bytes = C.crypto_scalarmult_curve25519_BYTES,
    secret_key_bytes = C.crypto_scalarmult_curve25519_SCALARBYTES,
    auth_code_bytes = C.crypto_auth_hmacsha512256_BYTES,
-   nonce_bytes = 32,
+   nonce_bytes = 32, -- must be >= salt_bytes
+   ephemeral_key_bytes = 16, -- 128 bits
+   salt_bytes = 4, -- 32 bits
    spi_t = ffi.typeof("union { uint32_t u32; uint8_t bytes[4]; }"),
    buffer_t = ffi.typeof("uint8_t[?]"),
-   key_t = ffi.typeof[[
-      union {
-         uint8_t bytes[20];
-         struct {
-            uint8_t key[16];
-            uint8_t salt[4];
-         } __attribute__((packed)) slot;
-      }
-   ]],
    nonce_message = subClass(header),
    key_message = subClass(header)
 }
@@ -550,7 +543,7 @@ function Protocol:new (spi, key, timeout)
       p2 = ffi.new(Protocol.buffer_t, Protocol.public_key_bytes),
       h  = ffi.new(Protocol.buffer_t, Protocol.auth_code_bytes),
       q  = ffi.new(Protocol.buffer_t, Protocol.secret_key_bytes),
-      e  = ffi.new(Protocol.key_t),
+      e  = ffi.new(Protocol.buffer_t, Protocol.ephemeral_key_bytes),
       hmac_state = ffi.new("struct crypto_auth_hmacsha512256_state"),
       hash_state = ffi.new("struct crypto_generichash_blake2b_state")
    }
@@ -597,12 +590,18 @@ function Protocol:receive_key (key_message)
    else return Protocol.code.protocol end
 end
 
-function Protocol:derive_ephemeral_keys ()
+function Protocol:derive_keying_material ()
    if self.status == Protocol.status.complete then
       self:reset()
       if self:derive_shared_secret() then
-         local rx = self:derive_key_material(self.p1, self.p2)
-         local tx = self:derive_key_material(self.p2, self.p1)
+         local rx = {
+            key = self:derive_ephemeral_key(self.p1, self.p2),
+            salt = self:derive_salt(self.n1)
+         }
+         local tx = {
+            key = self:derive_ephemeral_key(self.p2, self.p1),
+            salt = self:derive_salt(self.n2)
+         }
          return nil, rx, tx
       else return Protocol.code.paramter end
    else return Protocol.code.protocol end
@@ -660,15 +659,18 @@ function Protocol:derive_shared_secret ()
    return C.crypto_scalarmult_curve25519(self.q, self.s1, self.p2) == 0
 end
 
-function Protocol:derive_key_material (salt_a, salt_b)
+function Protocol:derive_ephemeral_key (salt_a, salt_b)
    local q, e, state = self.q, self.e, self.hash_state
    C.crypto_generichash_blake2b_init(state, nil, 0, ffi.sizeof(e))
    C.crypto_generichash_blake2b_update(state, q, ffi.sizeof(q))
    C.crypto_generichash_blake2b_update(state, salt_a, ffi.sizeof(salt_a))
    C.crypto_generichash_blake2b_update(state, salt_b, ffi.sizeof(salt_b))
-   C.crypto_generichash_blake2b_final(state, e.bytes, ffi.sizeof(e.bytes))
-   return { key = ffi.string(e.slot.key, ffi.sizeof(e.slot.key)),
-            salt = ffi.string(e.slot.salt, ffi.sizeof(e.slot.salt)) }
+   C.crypto_generichash_blake2b_final(state, e, ffi.sizeof(e))
+   return ffi.string(e, ffi.sizeof(e))
+end
+
+function Protocol:derive_salt (n)
+   return ffi.string(n, Protocol.salt_bytes)
 end
 
 function Protocol:reset ()
@@ -685,6 +687,8 @@ end
 assert(Protocol.preshared_key_bytes == 32)
 assert(Protocol.public_key_bytes == 32)
 assert(Protocol.auth_code_bytes == 32)
+assert(Protocol.ephemeral_key_bytes >= C.crypto_generichash_blake2b_BYTES_MIN)
+assert(Protocol.ephemeral_key_bytes <= C.crypto_generichash_blake2b_BYTES_MAX)
 
 -- Transport wrapper for vita-ske that encompasses an SPI to map requests to
 -- routes, and a message type to facilitate parsing.

--- a/src/program/vita/sodium.h
+++ b/src/program/vita/sodium.h
@@ -49,8 +49,8 @@ int crypto_scalarmult_curve25519(unsigned char *q,
 
 // crypto_generichash_blake2b.h
 enum {
-  crypto_generichash_blake2b_BYTES = 32U,
-  crypto_generichash_blake2b_KEYBYTES = 32U
+  crypto_generichash_blake2b_BYTES_MIN = 16U,
+  crypto_generichash_blake2b_BYTES_MAX = 64U
 };
 struct crypto_generichash_blake2b_state {
   uint64_t h[8];


### PR DESCRIPTION
A new version of Vita’s simple key exchange protocol and its implementation.

Changes:

Instead of using parts of the derived ephemeral key material as salts (as used
in RFC 4106) derive the salts from the authenticated nonces. Rationale: the
salts are public and it was suspicious and confusing that they were part of the
negotiated secret keys when they need not to be. Instead we do the obvious and
use part of the authenticated, unpredictable nonces that are exchanged during
the protocol for salts, and derive four bytes less ephemeral key material for
each key.