### PR TITLE
test.snabb: report load statistics every five seconds

### DIFF
--- a/src/program/vita/test.snabb
+++ b/src/program/vita/test.snabb
@@ -115,6 +115,7 @@ worker.start("DSP", ([[require("program.vita.vita").dsp_worker(%s)]])
 
 -- adapted from snabbnfv traffic
 
+local report = lib.throttle(5)
 local npackets = tonumber(main.parameters[2]) or 10e6
 local get_monotonic_time = require("ffi").C.get_monotonic_time
 local start, packets, bytes = 0, 0, 0
@@ -128,6 +129,9 @@ local function done ()
       packets = txpackets
       bytes = txbytes
       start = get_monotonic_time()
+   end
+   if report() then
+      engine.report_load()
    end
    return txpackets - packets >= npackets
 end


### PR DESCRIPTION
What it says on the tin. This may add some more value to archived test logs by showing some auxillary statistics and adding sort of implicit timestamps throughout a run. A report message looks like this:

```
load: time: 5.00s  fps: 2,531,807 fpGbps: 7.128 fpb: 171 bpp: 340  sleep: 0   us
```