### PR TITLE
Amend lib.pmu fixes for #40

### DIFF
--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -7,7 +7,7 @@ INCLUDE = *.* core arch jit syscall pf \
           program/vita program/top program/trace program/ps program/pci_bind
 
 INCLUDE_TEST = $(INCLUDE) \
-               lib/pmu.* apps/basic apps/test apps/packet_filter apps/ipv4 \
+               lib/pmu* apps/basic apps/test apps/packet_filter apps/ipv4 \
                lib/pcap apps/pcap \
                program/snsh program/snabbmark \
                lib/virtio apps/vhost apps/ipsec apps/ipv6 \

--- a/src/lib/pmu_x86.dasl
+++ b/src/lib/pmu_x86.dasl
@@ -199,7 +199,7 @@ if vendor == "GenuineIntel" then
       -- All available counters are globally enabled
       -- (IA32_PERF_GLOBAL_CTRL).
       writemsr(cpu, 0x38f, bit.bor(bit.lshift(0x3ULL, 32),
-                                   bit.lshift(1ULL, pmu_x86.ngeneral) - 1))
+                                   bit.lshift(1ULL, ngeneral) - 1))
       -- Enable all fixed-function counters (IA32_FIXED_CTR_CTRL)
       writemsr(cpu, 0x38d, 0x333)
       return {"instructions", "cycles", "ref_cycles"}, 0


### PR DESCRIPTION
Includes a regression fix from https://github.com/snabbco/snabb/pull/1354 and a fix to `Makefile.vita` to include all lib.pmu components.