### PR TITLE
KeyManager: AKE unit tests and polish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ before_script:
 script:
  - make -j
  - (cd src && sudo program/vita/selftest.snabb)
+ - (cd src && sudo ./snabb snsh -t program.vita.exchange)
  - (cd src && sudo program/vita/conftest.snabb)
  - (cd src && sudo program/vita/test.snabb IMIX 1e6 3)


### PR DESCRIPTION
The implementation of the AKE protocol fsm lends itself well to unit testing. This branch adds such tests (which should really have been included from the beginning) that clearly specify and assert valid and invalid state transitions and their effects. Perhaps tellingly, these uncovered some muddy areas in the implementation that have been fixed.