### PR TITLE
Adjust ttl defaults (sa-ttl: 10 minutes, negotiation-ttl: 5 seconds)

### DIFF
--- a/src/program/vita/exchange.lua
+++ b/src/program/vita/exchange.lua
@@ -148,8 +148,8 @@ KeyManager = {
       node_ip4 = {required=true},
       routes = {required=true},
       sa_db_path = {required=true},
-      negotiation_ttl = {default=10},
-      sa_ttl = {default=(24 * 60 * 60)}
+      negotiation_ttl = {default=5}, -- default:  5 seconds
+      sa_ttl = {default=(10 * 60)}   -- default: 10 minutes
    },
    shm = {
       rxerrors = {counter},

--- a/src/program/vita/test.lua
+++ b/src/program/vita/test.lua
@@ -114,7 +114,8 @@ function run_softbench (pktsize, npackets, nroutes, cpuspec)
       },
       packet_size = pktsize,
       nroutes = nroutes,
-      negotiation_ttl = nroutes
+      negotiation_ttl = nroutes,
+      sa_ttl = 16
    }
 
    local function configure_private_router_softbench (conf)
@@ -195,7 +196,7 @@ defaults = {
    route_prefix = {default="172.16"},
    nroutes = {default=1},
    packet_size = {default="IMIX"},
-   sa_ttl = {default=16},
+   sa_ttl = {},
    negotiation_ttl = {default=1}
 }
 private_interface_defaults = {


### PR DESCRIPTION
Also: do not default to 16 second sa-ttl in test.gen_configuration, but specify
so explicitly in test.run_softbench.