### PR TITLE
KeyManager: fixes and improvements

### DIFF
--- a/src/program/vita/exchange.lua
+++ b/src/program/vita/exchange.lua
@@ -542,6 +542,12 @@ function Protocol.nonce_message:new (config)
    return o
 end
 
+function Protocol.nonce_message:new_from_mem (mem, size)
+   if size == self:sizeof() then
+      return self:superClass().new_from_mem(self, mem, size)
+   end
+end
+
 function Protocol.nonce_message:nonce (nonce)
    local h = self:header()
    if nonce ~= nil then
@@ -556,6 +562,12 @@ function Protocol.key_message:new (config)
    o:public_key(config.public_key)
    o:auth_code(config.auth_code)
    return o
+end
+
+function Protocol.key_message:new_from_mem (mem, size)
+   if size == self:sizeof() then
+      return self:superClass().new_from_mem(self, mem, size)
+   end
 end
 
 function Protocol.key_message:spi (spi)


### PR DESCRIPTION
This contans a few improvements to the KeyManager app (see the commit messages for detail), notably:

- 49d6b21 introduces jitter to “grease” the protocol fsm
- 035ba16 throttles commiting of SA database changes in order to batch rapid updates
- a54fa4a adds delay before activating new outbound SAs after a rekey to ensure the receiving node is ready to accept packets on the newly negotiated SA