### PR TITLE
Add configuration option to disable KeyManager

### DIFF
--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -11,8 +11,9 @@
 
 static void worker_sigchld_handler(int sig, siginfo_t *si, void *unused)
 {
-  // Exit with child’s status
-  exit(si->si_status);
+  // Exit with child’s status if si_status != 0
+  if (si->si_status != 0)
+    exit(si->si_status);
 }
 
 // Setup a SIGCHLD handler to propagate child exits

--- a/src/program/vita/README.config
+++ b/src/program/vita/README.config
@@ -6,6 +6,9 @@ CONFIGURATION SYNTAX
     [ route { <route> } ]*
     [ negotiation-ttl <seconds>; ]
     [ sa-ttl <seconds>; ]
+    [ data-pane <boolean>; ]
+    [ outbound-sa { <sa> } ]*
+    [ inbound-sa { <sa> } ]*
 
   interface:=
     pci <busaddr>;
@@ -21,6 +24,13 @@ CONFIGURATION SYNTAX
     preshared-key <string>;
     spi <spi>;
     [ private-mtu <size>; ]
+
+ sa:=
+    route <string>;
+    spi <spi>;
+    aead "aes-gcm-16-icv";
+    key <string>;
+    salt <string>;
 
 NOTES
 
@@ -58,8 +68,8 @@ NOTES
   encoded as a hexadecimal string (two digits for each octet, most significant
   digit first). Additionally, a unique Security Parameter Index (SPI), which
   must be a positive integer equal or greater than 256, is specified for
-  tagging and associating encrypted traffic for a given route. Like the
-  pre-shared key, the SPI must be the same for both ends of a route.
+  tagging and associating key exchange protocol messages for a given route.
+  Like the pre-shared key, the SPI must be the same for both ends of a route.
 
   A suitable key could be obtained using the following command:
 
@@ -75,6 +85,14 @@ NOTES
   While the default configuration should be generally applicable, the
   negotiation timeout and lifetime of Security Associations (SA) can be
   specified in seconds.
+
+  The 'data-plane' toggle can be set to disable Vita’s key manager. In this
+  case the options 'negotiation-ttl', 'sa-ttl' as well as 'route.spi' and
+  'route.preshared-key are ignored, and the user is expected to configure
+  'outbound-sa' and 'inbound-sa' themselves. Each SA must name an existing
+  route, an SPI equal or greater than 256, and specify a 128-bit key and a
+  32-bit salt respectively, encoded as hexadecimal strings (two digits for each
+  octet, most significant digit first).
 
 EXAMPLE
 

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -44,8 +44,8 @@ module vita-esp-gateway {
 
   // Active outbound SAs (at most one per route) and inbound SAs (possibly
   // multiple per route.) 
-  list outbound-sa { uses sa; unique "route spi"; config false; }
-  list inbound-sa { uses sa; unique "spi"; config false; }
+  list outbound-sa { key "spi"; unique "route"; uses sa; }
+  list inbound-sa { key "spi"; uses sa; }
 
   // Types 
   typedef id { type string { pattern '[\w_]+'; } }

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -47,6 +47,10 @@ module vita-esp-gateway {
   list outbound-sa { key "spi"; unique "route"; uses sa; }
   list inbound-sa { key "spi"; uses sa; }
 
+  // If true, disables KeyManager (route.spi, route.preshared-key,
+  // negotiation-ttl, and sa-ttl are ignored.)
+  leaf data-plane { type boolean; }
+
   // Types 
   typedef id { type string { pattern '[\w_]+'; } }
   typedef pci-address {

--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -38,6 +38,7 @@ local confspec = {
    route = {default={}},
    negotiation_ttl = {},
    sa_ttl = {},
+   data_plane = {},
    inbound_sa = {default={}},
    outbound_sa = {default={}}
 }
@@ -324,10 +325,12 @@ function configure_public_router (conf, append)
    config.link(c, "PublicDispatch.protocol4_unreachable -> PublicICMP4.protocol_unreachable")
    config.link(c, "PublicICMP4.output -> PublicNextHop.icmp4")
 
-   config.app(c, "Protocol_in_Tx", Transmitter, "Protocol_in")
-   config.app(c, "Protocol_out_Rx", Receiver, "Protocol_out")
-   config.link(c, "PublicDispatch.protocol -> Protocol_in_Tx.input")
-   config.link(c, "Protocol_out_Rx.output -> PublicNextHop.protocol")
+   if not conf.data_plane then
+      config.app(c, "Protocol_in_Tx", Transmitter, "Protocol_in")
+      config.app(c, "Protocol_out_Rx", Receiver, "Protocol_out")
+      config.link(c, "PublicDispatch.protocol -> Protocol_in_Tx.input")
+      config.link(c, "Protocol_out_Rx.output -> PublicNextHop.protocol")
+   end
 
    for id, route in pairs(conf.route) do
       local public_out = "PublicNextHop."..id
@@ -395,6 +398,8 @@ end
 function configure_exchange (conf, append)
    conf = parse_conf(conf)
    local c = append or config.new()
+
+   if conf.data_plane then return end
 
    if not conf.public_interface then return c end
 


### PR DESCRIPTION
This adds a configuration option do disable the automated key exchange and expiry provided by KeyManager. In this mode, an external program (for instance, a modified version of the libreSwan IKE implementation) would use `snabb config` to manage SAs explicitly.