### PR TITLE
Model gateway state in schema and implement get-state support

### DIFF
--- a/src/program/vita/schemata.lua
+++ b/src/program/vita/schemata.lua
@@ -1,19 +1,155 @@
--- Use of this source code is governed by the GNU Affero General Public License
--- as published by the Free Software Foundation, either version 3 or (at your
--- option) any later version; see src/program/vita/COPYING.
+-- Use of this source code is governed by the GNU AGPL license; see COPYING.
 
 module(...,package.seeall)
 
+local shm = require("core.shm")
+local counter = require("core.counter")
+local data = require("lib.yang.data")
+local state = require('lib.yang.state')
 local yang = require("lib.yang.yang")
+
+
+-- Load Vita’s native schemata
 
 yang.add_schema(require("program.vita.vita_esp_gateway_yang",
                         "program/vita/vita-esp-gateway.yang"))
 yang.add_schema(require("program.vita.vita_ephemeral_keys_yang",
                         "program/vita/vita-ephemeral-keys.yang"))
 
+
+-- State reader support
+
+local function open_counters (path)
+   local counters = {}
+   for _, file in ipairs(shm.children(path)) do
+      local name, type = file:match("(.*)[.](.*)$")
+      local canonical_name = name:gsub('[^%w-]', '-')
+      if type == 'counter' then
+         counters[canonical_name] = counter.open(path..'/'..file)
+      end
+   end
+   return counters
+end
+
+function configuration_for_worker (worker, _)
+   return worker.graph
+end
+
+function compute_state_reader (schema_name)
+   assert(schema_name == 'vita-esp-gateway')
+   local schema = yang.load_schema_by_name(schema_name)
+   local grammar = data.data_grammar_from_schema(schema, false)
+
+   local gateway_state_gmr =
+      grammar.members["gateway-state"]
+   local sa_state_gmr =
+      gateway_state_gmr.members["inbound-sa"].values["sa-state"]
+
+   return function (pid, graph)
+      local gateway_state = {}
+
+      local interface_state = {
+         PrivateNIC = "private-interface",
+         PublicNIC = "public-interface"
+      }
+      for app, member in pairs(interface_state) do
+         local id = data.normalize_id(member)
+         local grammar = gateway_state_gmr.members[member]
+         local counters = {}
+         if graph.apps[app] then
+            local pciaddr = graph.apps[app].arg.pciaddr
+            counters = open_counters("/"..pid.."/pci/"..pciaddr)
+         end
+         gateway_state[id] = state.state_reader_from_grammar(grammar)(counters)
+      end
+
+      local app_state = {
+         PrivateNextHop = "private-next-hop",
+         PublicNextHop = "public-next-hop",
+         PrivateDispatch = "private-dispatch",
+         PublicDispatch = "public-dispatch",
+         InboundDispatch = "inbound-dispatch",
+         OutboundTTL = "outbound-ttl",
+         InboundTTL = "inbound-ttl",
+         PrivateRouter = "private-router",
+         PublicRouter = "public-router",
+         PrivateICMP4 = "private-icmp4",
+         PublicICMP4 = "public-icmp4",
+         InboundICMP4 = "inbound-icmp4",
+         KeyManager = "key-manager"
+      }
+      for app, member in pairs(app_state) do
+         local id = data.normalize_id(member)
+         local grammar = gateway_state_gmr.members[member]
+         local counters = {}
+         if graph.apps[app] then
+            counters = open_counters("/"..pid.."/apps/"..app)
+         end
+         gateway_state[id] = state.state_reader_from_grammar(grammar)(counters)
+      end
+
+      gateway_state.inbound_sa = {}
+      for app, _ in pairs(graph.apps) do
+         local sa = app:match("^DSP_%w+_(%d+)$")
+         if sa then
+            local spi = tonumber(sa)
+            local counters = open_counters("/"..pid.."/apps/"..app)
+            local reader = state.state_reader_from_grammar(sa_state_gmr)
+            gateway_state.inbound_sa[spi] =
+               {spi=spi, sa_state=reader(counters)}
+         end
+      end
+
+      return gateway_state
+   end
+end
+
+function process_states (states)
+   local gateway_state = {}
+
+   local containers =
+      {"private_interface", "public_interface",
+       "private_next_hop", "public_next_hop",
+       "private_dispatch", "public_dispatch", "inbound_dispatch",
+       "outbound_ttl", "inbound_ttl", "private_router", "public_router",
+       "private_icmp4", "public_icmp4", "inbound_icmp4", "key_manager"}
+   for _, container in ipairs(containers) do
+      local acc = {}
+      for _, state in ipairs(states) do
+         for member, value in pairs(state[container]) do
+            acc[member] = (acc[member] or 0) + value
+         end
+      end
+      gateway_state[container] = acc
+   end
+
+   local lists =
+      {"inbound_sa"}
+   for _, list in ipairs(lists) do
+      local acc = {}
+      for _, state in ipairs(states) do
+         for key, value in pairs(state[list]) do
+            acc[key] = value
+         end
+      end
+      gateway_state[list] = acc
+   end
+
+   return {gateway_state = gateway_state}
+end
+
+
+-- Module exports
+
 return {
-   ['esp-gateway'] =
-      yang.load_schema_by_name('vita-esp-gateway'),
-   ['ephemeral-keys'] =
-      yang.load_schema_by_name('vita-ephemeral-keys')
+   -- Schemata
+   ['esp-gateway'] = yang.load_schema_by_name('vita-esp-gateway'),
+   ['ephemeral-keys'] = yang.load_schema_by_name('vita-ephemeral-keys'),
+   -- State reader support
+   support = {
+      configuration_for_worker = configuration_for_worker,
+      compute_state_reader = compute_state_reader,
+      process_states = process_states
+   }
+   
 }

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -273,7 +273,7 @@ module vita-esp-gateway {
 
     container public-router {
       description "Routing errors for inbound packets (to be decapsulated.)";
-      leaf oute-errors {
+      leaf route-errors {
         type yang:zero-based-counter64;
         description
           "Count of packets that were dropped because their destination did not

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -1,13 +1,13 @@
 module vita-esp-gateway {
-  // Metadata
+  // METADATA
   namespace vita:esp-gateway;
   prefix esp-gateway;
 
-  // Imports
+  // IMPORTS
   import ietf-yang-types { prefix yang; }
   import ietf-inet-types { prefix inet; }
 
-  // Application model
+  // APPLICATION MODEL
   grouping interface {
     leaf pci { type pci-address; mandatory true; }
     leaf ip4 { type inet:ipv4-address-no-zone; mandatory true; }
@@ -33,7 +33,7 @@ module vita-esp-gateway {
   leaf negotiation-ttl { type time-to-live; }
   leaf sa-ttl { type time-to-live; }
 
-  // Negotiated by Key Manager
+  // Negotiated by Key Manager or configured manually
   grouping sa {
     leaf route { type id; mandatory true; } // Parent route identifier
     leaf spi { type spi; mandatory true; }
@@ -47,7 +47,471 @@ module vita-esp-gateway {
   list outbound-sa { uses sa; unique "route"; unique "spi"; config false; }
   list inbound-sa { uses sa; unique "spi"; config false; }
 
-  // Types 
+  // APPLICATION STATE
+  container gateway-state {
+    description "Gateway state counters for monitoring and troubleshooting.";
+    config false;
+
+    // Interface state
+    grouping interface-state {
+      leaf rxbytes {
+        type yang:zero-based-counter64;
+        description
+          "Total bytes received.";
+      }
+      leaf rxpackets {
+        type yang:zero-based-counter64;
+        description
+          "Total packets received.";
+      }
+      leaf rxmcast {
+        type yang:zero-based-counter64;
+        description
+          "Count of multicast packets received.";
+      }
+      leaf rxbcast {
+        type yang:zero-based-counter64;
+        description
+          "Count of broadcast packets received.";
+      }
+      leaf rxdrop {
+        type yang:zero-based-counter64;
+        description
+          "Count of incoming packets that were dropped.";
+      }
+      leaf rxerrors {
+        type yang:zero-based-counter64;
+        description
+          "Count of receive errors.";
+      }
+      leaf txbytes {
+        type yang:zero-based-counter64;
+        description
+          "Total bytes transmitted.";
+      }
+      leaf txpackets {
+        type yang:zero-based-counter64;
+        description
+          "Total packets transmitted.";
+      }
+      leaf txmcast {
+        type yang:zero-based-counter64;
+        description
+          "Count of multicast packets transmitted.";
+      }
+      leaf txbcast {
+        type yang:zero-based-counter64;
+        description
+          "Count of broadcast packets transmitted.";
+      }
+      leaf txdrop {
+        type yang:zero-based-counter64;
+        description
+          "Count of outgoing packets that were dropped.";
+      }
+      leaf txerrors {
+        type yang:zero-based-counter64;
+        description
+          "Count of transmit errors.";
+      }
+      leaf rxdmapackets {
+        type yang:zero-based-counter64;
+        description
+          "Count of incoming packets that were copied to main memory.";
+      }
+    }
+
+    container private-interface {
+      description "Private interface statistics.";
+      uses interface-state;
+    }
+
+    container public-interface {
+      description "Public interface statistics.";
+      uses interface-state;
+    }
+
+    // Next-hop state
+    grouping next-hop-state {
+      leaf arp-requests {
+        type yang:zero-based-counter64;
+        description
+          "Count of ARP requests sent.";
+      }
+      leaf arp-replies {
+        type yang:zero-based-counter64;
+        description
+          "Count of ARP replies sent.";
+      }
+      leaf arp-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of declined ARP requests.";
+      }
+      leaf adresses-added {
+        type yang:zero-based-counter64;
+        description
+          "Count of learned addresses.";
+      }
+      leaf adresses-updated {
+        type yang:zero-based-counter64;
+        description
+          "Count of times an address was updated.";
+      }
+    }
+
+    container private-next-hop {
+      description "Private next-hop events.";
+      uses next-hop-state;
+    }
+
+    container public-next-hop {
+      description "Public next-hop events.";
+      uses next-hop-state;
+    }
+
+    // Protocol dispatch state
+    container private-dispatch {
+      description "Protocol dispatch errors for packets received on the
+                   private interface.";
+      leaf rxerrors {
+        type yang:zero-based-counter64;
+        description
+          "Total number of unhandled packets.";
+      }
+      leaf ethertype-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they had an unsupported
+           Ethertype.";
+      }
+      leaf checksum-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they had an invalid IP
+           checksum.";
+      }
+    }
+
+    container public-dispatch {
+      description "Protocol dispatch errors for packets received on the
+                   public interface.";
+      leaf rxerrors {
+        type yang:zero-based-counter64;
+        description
+          "Total number of unhandled packets.";
+      }
+      leaf ethertype-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they had an unsupported
+           Ethertype.";
+      }
+      leaf protocol-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they were of an
+           unsupported protocol.";
+      }
+      leaf fragment-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they were IP fragments.";
+      }
+    }
+
+    container inbound-dispatch {
+      description "Protocol dispatch errors inbound packets that were
+                   successfully decapsulated.";
+      leaf protocol-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they were of an
+           unsupported protocol.";
+      }
+    }
+
+    // TTL state
+    grouping time-to-live-state {
+      leaf protocol-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because their TTL reached zero.";
+      }
+    }
+
+    container outbound-ttl {
+      description "TTL errors for outbound packets.";
+      uses time-to-live-state;
+    }
+
+    container inbound-ttl {
+      description "TTL errors for inbound packets.";
+      uses time-to-live-state;
+    }
+
+    // Router state
+    container private-router {
+      description "Routing errors for outbound packets (to be encapsulated.)";
+      leaf rxerrors {
+        type yang:zero-based-counter64;
+        description
+          "Total packets that were dropped because they were not routable.";
+      }
+      leaf route-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because their destination did not
+           match any configured route.";
+      }
+      leaf mtu-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because they exceeded the MTU.";
+      }
+    }
+
+    container public-router {
+      description "Routing errors for inbound packets (to be decapsulated.)";
+      leaf oute-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of packets that were dropped because their destination did not
+           match any configured route.";
+      }
+    }
+
+    // ICMP state
+    grouping icmp4-state {
+      leaf rxerrors {
+        type yang:zero-based-counter64;
+        description
+          "Total ICMPv4 messages that were dropped because they were invalid.";
+      }
+      leaf protocol-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages that were dropped because their checksum
+           was invalid, or they were IP fragments.";
+      }
+      leaf type-not-implemented-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages received that had an unrecognized type.";
+      }
+      leaf code-not-implemented-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages received that had an unrecognized code.";
+      }
+      leaf destination-unreachable {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages received of type
+           'destination unreachable'."; 
+      }
+      leaf net-unreachable {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'destination unreachable' messages received with
+           code 'net unreachable'.";
+      }
+      leaf host-unreachable {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'destination unreachable' messages received with
+           code 'host unreachable'.";
+      }
+      leaf protocol-unreachable {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'destination unreachable' messages received with
+           code 'protocol unreachable'.";
+      }
+      leaf port-unreachable {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'destination unreachable' messages received with
+           code 'port unreachable'.";
+      }
+      leaf fragmentation-needed {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'destination unreachable' messages received with
+           code 'fragmentation needed and DF set'.";
+      }
+      leaf source-route-failed {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'destination unreachable' messages received with
+           code 'source route failed'.";
+      }
+      leaf time-exceeded {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages received of type
+           'time exceeded'."; 
+      }
+      leaf transit-ttl-exceeded {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'time exceeded' messages received with code
+           'time to live exceeded in transit'.";
+      }
+      leaf fragment-reassembly-time-exceeded {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'time exceeded' messages received with code
+           'fragment reassembly time exceeded'.";
+      }
+      leaf parameter-problem {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages received of type
+           'parameter problem'."; 
+      }
+      leaf redirect {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 messages received of type
+           'redirect'."; 
+      }
+      leaf redirect-net {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'redirect' messages received with code
+           'Redirect datagrams for the Network'.";
+      }
+      leaf redirect-host {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'redirect' messages received with code
+           'Redirect datagrams for the Host'.";
+      }
+      leaf redirect-tos-net {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'redirect' messages received with code
+           'Redirect datagrams for the Type of Service and Network'.";
+      }
+      leaf redirect-tos-host {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 'redirect' messages received with code
+           'Redirect datagrams for the Type of Service and Host'.";
+      }
+      leaf echo-request {
+        type yang:zero-based-counter64;
+        description
+          "Count of ICMPv4 echo requests handled.";
+      }
+    }
+
+    container private-icmp4 {
+      description "ICMPv4 events on the private interface.";
+      uses icmp4-state;
+    }
+
+    container public-icmp4 {
+      description "ICMPv4 events on the public interface.";
+      uses icmp4-state;
+    }
+
+    container inbound-icmp4 {
+      description "ICMPv4 events triggered by encapsulated messages on the
+                   public interface.";
+      uses icmp4-state;
+    }
+
+    // SA state
+    list inbound-sa {
+      key "spi";
+      leaf spi { type spi; }
+      container sa-state {
+        leaf rxerrors {
+          type yang:zero-based-counter64;
+          description
+            "Count of all packets destined to this SA that were dropped.";
+        }
+        leaf protocol-errors {
+          type yang:zero-based-counter64;
+          description
+            "Count of packets that were dropped because the encapsulated
+             protocol was not supported.";
+        }
+        leaf decrypt-errors {
+          type yang:zero-based-counter64;
+          description
+            "Count of packets that were dropped because of errors while
+             decapsulating or authenticating the security payload.";
+        }
+      }
+    }
+
+    // KeyManager state
+    container key-manager {
+      description "Authenticated key exchange and SA management events.";
+      leaf rxerrors {
+        type yang:zero-based-counter64;
+        description
+          "Total number key exchange requests received that were invalid.";
+      }
+      leaf route-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of key exchange requests received that couldn’t be associated
+           to any configured route.";
+      }
+      leaf protocol-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of key exchange requests received that violated the protocol
+         (i.e., order of messages and message format).";
+      }
+      leaf authentication-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of key exchange requests received that failed to authenticate
+         (i.e., had an erroneous message authentication code, this may include
+         packets corrupted during transit.)";
+      }
+      leaf public-key-errors {
+        type yang:zero-based-counter64;
+        description
+          "Count of key exchange requests received offering public keys that
+           were rejected because they were considered unsafe.";
+      }
+      leaf negotiations-initiated {
+        type yang:zero-based-counter64;
+        description
+          "Count of key exchange negotiations initiated.";
+      }
+      leaf negotiations-expired {
+        type yang:zero-based-counter64;
+        description
+          "Count of key exchange negotiations expired due to exceeding
+         negotiation-ttl.";
+      }
+      leaf nonces-negotiated {
+        type yang:zero-based-counter64;
+        description
+          "Count of nonce pairs that were exchanged (elevated count can
+           indicate a denial-of-service attack.)";
+      }
+      leaf keypairs-negotiated {
+        type yang:zero-based-counter64;
+        description
+          "Count of ephemeral key pairs that were exchanged.";
+      }
+      leaf keypairs-expired {
+        type yang:zero-based-counter64;
+        description
+          "Count of ephemeral key pairs that have expired due to sa-ttl.";
+      }
+    }
+  }
+
+  // TYPES 
   typedef id { type string { pattern '[\w_]+'; } }
   typedef pci-address {
     type string {

--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -20,17 +20,13 @@ local ethernet = require("lib.protocol.ethernet")
 local ipv4 = require("lib.protocol.ipv4")
 local numa = require("lib.numa")
 local yang = require("lib.yang.yang")
-local file = require("lib.stream.file")
-local cltable = require("lib.cltable")
+local ptree = require("lib.ptree.ptree")
+local CPUSet = require("lib.cpuset")
 local pci = require("lib.hardware.pci")
 local S = require("syscall")
 local ffi = require("ffi")
 local usage = require("program.vita.README_inc")
 local confighelp = require("program.vita.README_config_inc")
-
-local ptree = require("lib.ptree.ptree")
-local generic_schema_support = require("lib.ptree.support").generic_schema_config_support
-local CPUSet = require("lib.cpuset")
 
 local confspec = {
    private_interface = {},
@@ -134,10 +130,10 @@ function run_vita (opt)
          return actions
       end,
       update_mutable_objects_embedded_in_app_initargs = function () end,
-      compute_state_reader = generic_schema_support.compute_state_reader,
-      configuration_for_worker = generic_schema_support.configuration_for_worker,
-      process_states = generic_schema_support.process_states,
       compute_apps_to_restart_after_configuration_update = function () end,
+      compute_state_reader = schemata.support.compute_state_reader,
+      configuration_for_worker = schemata.support.configuration_for_worker,
+      process_states = schemata.support.process_states,
       translators = {}
    }
    local function purify (setup_fn)


### PR DESCRIPTION
This extends the `vita-esp-gateway` model to describe the various state counters exposed by Vita, and implements the supporting functions needed to query this state via `snabb config get-state`.

Caveats:

- Only includes device-global statistics (no per-queue stats), i.e. both interfaces will show the same state if they use the same device
- Does not include any “positive” link statistics (might be nice to model e.g. how many packets flow over which route, etc...)

Depends on #56 

Resolves #17 