### PR TITLE
Interlink: optimize rebalance

### DIFF
--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -52,8 +52,7 @@ local max_packets = 1e6
 ffi.cdef([[
 struct freelist {
     int32_t lock[1];
-    uint64_t nfree;
-    uint64_t max;
+    uint32_t nfree, max;
     struct packet *list[]]..max_packets..[[];
 };
 ]])


### PR DESCRIPTION
Optimizes the slow loops that rebalance the packet freelists. This change might not be worth the code: while it significantly reduces the latency of rebalancing operations (as observed using the timeline) in micro benchmarks, it does not have measurable impact on more realistic benchmarks like Vita’s `test.snabb`, likely due to the fact that duplex packet flow avoids most of the need to rebalance freelists at all.

Notably, when testing this change using Vita’s `test.snabb` a performance regression was observed, possibly due to 8f5569b (alignment?). Have do dig into that in case this optimization becomes relevant.