### PR TITLE
lib.ptree.worker: claim SNABB_WORKER_NAME on start

### DIFF
--- a/src/core/worker.lua
+++ b/src/core/worker.lua
@@ -41,10 +41,13 @@ function start (name, luacode)
       shm.alias("group", "/"..S.getppid().."/group")
       -- Save the code we want to run in the environment.
       S.setenv("SNABB_PROGRAM_LUACODE", luacode, true)
+      -- Save this worker's qualified name in the environment.
+      local parent = engine.program_name or S.getppid()
+      S.setenv("SNABB_WORKER_NAME", parent.."/"..name, true)
       -- Restart the process with execve().
       -- /proc/$$/exe is a link to the same Snabb executable that we are running
       local filename = ("/proc/%d/exe"):format(S.getpid())
-      local argv = { ("[snabb worker '%s' for %d]"):format(name, S.getppid()) }
+      local argv = { ("[snabb worker '%s' for %s]"):format(name, parent) }
       lib.execv(filename, argv)
    else
       -- Parent process

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -108,6 +108,7 @@ function Worker:main ()
 end
 
 function main (opts)
+   engine.claim_name(os.getenv("SNABB_WORKER_NAME"))
    return new_worker(opts):main()
 end
 


### PR DESCRIPTION
- core.worker: set SNABB_WORKER_NAME in worker environment 
- lib.ptree.worker: claim SNABB_WORKER_NAME