### PR TITLE
Exclude Ethernet header from MTU calculations

### DIFF
--- a/src/program/vita/README.config
+++ b/src/program/vita/README.config
@@ -75,12 +75,12 @@ NOTES
 
     head -c 32 /dev/urandom | hexdump -e '/1 "%02X"'
 
-  Optionally, the gateway’s MTU can be specified in bytes. The default and
-  maximum permitted value is 8937. Since Vita performs neither fragmentation
-  nor reassembly it may be necessary to adjust the next-hop MTU accordingly.
-  Note that packets leaving the public interface will have an added packet size
-  overhead due to encapsulation (up to 57 bytes for IPv4 and up to 77 bytes for
-  IPv6.)
+  Optionally, the gateway’s MTU (excluding Ethernet overhead) can be specified
+  in bytes. The default and maximum permitted value is 8923. Since Vita
+  performs neither fragmentation nor reassembly it may be necessary to adjust
+  the next-hop MTU accordingly. Note that packets leaving the public interface
+  will have an added packet size overhead due to encapsulation (up to 57 bytes
+  for IPv4 and up to 77 bytes for IPv6.)
 
   While the default configuration should be generally applicable, the
   negotiation timeout and lifetime of Security Associations (SA) can be

--- a/src/program/vita/route.lua
+++ b/src/program/vita/route.lua
@@ -68,7 +68,7 @@ function PrivateRouter:route (p)
    assert(self.ip4:new_from_mem(p.data, p.length))
    local route = self:find_route4(self.ip4:dst())
    if route then
-      if p.length + ethernet:sizeof() <= self.mtu then
+      if p.length <= self.mtu then
          link.transmit(route, p)
       else
          counter.add(self.shm.rxerrors)

--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -31,7 +31,7 @@ local confighelp = require("program.vita.README_config_inc")
 local confspec = {
    private_interface = {},
    public_interface = {},
-   mtu = {default=8937},
+   mtu = {default=8923},
    route = {default={}},
    negotiation_ttl = {},
    sa_ttl = {},


### PR DESCRIPTION
Because Snabb operates at L2 we are used to including the Etherner header in packet size calculations, but IP MTUs are usually expected to be–as I understand–specified excluding the Ethernet header. This change makes it so in Vita, in order to provide a more natural interface to network engineers.