### PR TITLE
Ensure SA database updates are atomic

### DIFF
--- a/src/lib/ptree/action_codec.lua
+++ b/src/lib/ptree/action_codec.lua
@@ -129,15 +129,13 @@ local function encoder()
    end
    function encoder:config(class, arg)
       local file_name = random_file_name()
-      local tmp_name = file_name..".tmp"
       if class.yang_schema then
          yang.compile_config_for_schema_by_name(class.yang_schema, arg,
-                                                tmp_name)
+                                                file_name)
       else
          if arg == nil then arg = {} end
-         binary.compile_ad_hoc_lua_data_to_file(tmp_name, arg)
+         binary.compile_ad_hoc_lua_data_to_file(file_name, arg)
       end
-      assert(S.rename(tmp_name, file_name)) -- ensure atomic update
       self:string(file_name)
    end
    function encoder:finish()

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -323,8 +323,7 @@ end
 function data_compiler_from_grammar(emit_data, schema_name, schema_revision)
    return function(data, filename, source_mtime)
       source_mtime = source_mtime or {sec=0, nsec=0}
---      local stream = file.tmpfile("rusr,wusr,rgrp,roth", lib.dirname(filename))
-      local stream = assert(file.open(filename, 'w'))
+      local stream = file.tmpfile("rusr,wusr,rgrp,roth", lib.dirname(filename))
       local strtab = string_table_builder()
       local header = header_t(
          MAGIC, VERSION, source_mtime.sec, source_mtime.nsec,
@@ -341,7 +340,7 @@ function data_compiler_from_grammar(emit_data, schema_name, schema_revision)
       assert(stream:seek('set', 0))
       -- Fix up header.
       stream:write_struct(header_t, header)
---      stream:rename(filename)
+      stream:rename(filename)
       stream:close()
    end
 end

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -323,6 +323,7 @@ end
 function data_compiler_from_grammar(emit_data, schema_name, schema_revision)
    return function(data, filename, source_mtime)
       source_mtime = source_mtime or {sec=0, nsec=0}
+--      local stream = file.tmpfile("rusr,wusr,rgrp,roth", lib.dirname(filename))
       local stream = assert(file.open(filename, 'w'))
       local strtab = string_table_builder()
       local header = header_t(
@@ -340,6 +341,7 @@ function data_compiler_from_grammar(emit_data, schema_name, schema_revision)
       assert(stream:seek('set', 0))
       -- Fix up header.
       stream:write_struct(header_t, header)
+--      stream:rename(filename)
       stream:close()
    end
 end

--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -157,18 +157,12 @@ function run_vita (opt)
    }
 
    -- Listen for SA database changes.
-   local notify_fd, sa_db_wd = assert(S.inotify_init("cloexec, nonblock"))
+   local sa_db_last_modified
    local function sa_db_needs_reload ()
-      if not sa_db_wd then
-         sa_db_wd = notify_fd:inotify_add_watch(sa_db_path, "close_write")
-         -- sa_db_wd ~= nil means the SA database was newly created and we
-         -- should load it.
-         return (sa_db_wd ~= nil)
-      else
-         local events, err = notify_fd:inotify_read()
-         -- Any event indicates the SA database was written to and we should
-         -- reload it.
-         return not (err and assert(err.again, err)) and #events > 0
+      local stat = S.stat(sa_db_path)
+      if stat and stat.st_mtime ~= sa_db_last_modified then
+         sa_db_last_modified = stat.st_mtime
+         return true
       end
    end
 


### PR DESCRIPTION
This fixes a bug where Vita would attempt to load partially written SA database state. (Cleans up a left-over mess from #56.