### PR TITLE
vita/tunnel: disable ESP re-synchronization by default

### DIFF
--- a/src/program/vita/tunnel.lua
+++ b/src/program/vita/tunnel.lua
@@ -60,7 +60,7 @@ Decapsulate = {
       key = {required=true},
       salt = {required=true},
       window_size = {},
-      resync_threshold = {},
+      resync_threshold = {default=1/0}, -- disable resynchronization
       resync_attempts = {},
       auditing = {}
    },


### PR DESCRIPTION
I consider the re-synchronization feature of ESP a misfeature of the standard. It should never come into effect in sensible setups, and presents a tricky bit of logic. Short of removing the feature from `lib.ipsec.esp` altogether, this change should make sure the related code is never run.