### PR TITLE
lib.tsc: avoid re-calibrating rdtsc on every call to tsc:new()

### DIFF
--- a/src/program/vita/clitest.sh
+++ b/src/program/vita/clitest.sh
@@ -30,7 +30,7 @@ program/vita/genconf.snabb < program/vita/clitest.conf > $conf
 sleep 1
 
 [ $(./snabb config get-state $name \
-            /gateway-state/key-manager/negotiations-initiated) = 0 ]
+            /gateway-state/private-router/route-errors) = 0 ]
 
 ./snabb config set $name / <<EOF
 EOF


### PR DESCRIPTION
See #83 