### PR TITLE
Control burst size

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -18,7 +18,7 @@ local S         = require("syscall")
 require("core.packet_h")
 
 -- Packet per pull
-pull_npackets = math.floor(link.max / 10)
+pull_npackets = 300 -- Vita specific sweet spot
 
 -- Set to true to enable logging
 log = false

--- a/src/program/vita/test.lua
+++ b/src/program/vita/test.lua
@@ -260,8 +260,8 @@ function gen_packets (conf)
    local sim_packets = {}
    local sizes = traffic_templates[conf.packet_size]
               or {tonumber(conf.packet_size)}
-   for _, size in ipairs(sizes) do
-      for i = 1, math.floor(1000 / #sizes / conf.nroutes) do
+   for i = 1, math.floor(1000 / #sizes / conf.nroutes) do
+      for _, size in ipairs(sizes) do
          for route = 1, conf.nroutes do
             table.insert(sim_packets, gen_packet(conf, route, size))
          end


### PR DESCRIPTION
- there was a bug in `vita.test.gen_packets` combined with `apps.test.synth` that caused the benchmark test to effectively use a burst size of 1000
- I took the opportunity to benchmark different burst sizes and set a sweet spot in `engine.pull_npackets` for Vita

![screenshot from 2019-03-08 12-55-30](https://user-images.githubusercontent.com/4933566/54027754-e2f93100-41a2-11e9-8d7e-e1450ca8be6c.png)

Note: this is for 60 byte packets, and includes encap+decap for each packet. The seemingly amazing efficiency gain beyond a burst size of 1000 is due to the fact that our link size is ~1000 and packets in a burst beyond that limit are dropped.