### PR TITLE
Cloud additions and fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,30 +5,19 @@
 { pkgs ? (import <nixpkgs> {})
 , source ? ./.
 , version ? "dev"
-, supportOpenstack ? true
+, test ? false
 }:
 
 with pkgs;
 
 stdenv.mkDerivation rec {
-  name = "snabb-${version}";
+  name = "vita-${version}";
   inherit version;
   src = lib.cleanSource source;
 
   buildInputs = [ makeWrapper ];
 
-  patchPhase = ''
-    patchShebangs .
-
-    # some hardcodeism
-    for f in $(find src/program/snabbnfv/ -type f); do
-      substituteInPlace $f --replace "/bin/bash" "${bash}/bin/bash"
-    done
-  '' + lib.optionalString supportOpenstack ''
-    # We need a way to pass $PATH to the scripts
-    sed -i '2iexport PATH=${git}/bin:${mariadb}/bin:${which}/bin:${procps}/bin:${coreutils}/bin' src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh.inc
-    sed -i '2iexport PATH=${git}/bin:${coreutils}/bin:${diffutils}/bin:${nettools}/bin' src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.sh.inc
-  '';
+  RECIPE = if test then "Makefile.vita-test" else "Makefile.vita";
 
   preBuild = ''
     make clean
@@ -37,6 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp src/snabb $out/bin
+    ln -s snabb $out/bin/vita
   '';
 
   enableParallelBuilding = true;

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -12,7 +12,7 @@ INCLUDE = *.* core arch jit syscall pf \
           apps/basic apps/interlink apps/intel_mp apps/intel_avf apps/xdp \
           apps/ipv6/nd_light.lua lib/pcap \
           program/vita program/config program/ps program/pci_bind \
-          program/top program/shm
+          program/top program/shm program/rrdcat
 
 INCLUDE_TEST = $(INCLUDE) \
                lib/pmu* apps/test apps/packet_filter apps/ipv4 \

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -158,12 +158,20 @@ local function assert_irqbalanced_disabled (warn)
    end
 end
 
+local function read_cpu_performance_governor (cpu)
+   local path = '/sys/devices/system/cpu/cpu'..cpu..'/cpufreq/scaling_governor'
+   local f = io.open(path)
+   if not f then return "unknown" end
+   local gov = f:read()
+   f:close()
+   return gov
+end
+
 local function check_cpu_performance_tuning (cpu, strict)
    local warn = warn
    if strict then warn = die end
    assert_irqbalanced_disabled(warn)
-   local path = '/sys/devices/system/cpu/cpu'..cpu..'/cpufreq/scaling_governor'
-   local gov = assert(io.open(path)):read()
+   local gov = read_cpu_performance_governor(cpu)
    if not gov:match('performance') then
       warn('Expected performance scaling governor for CPU %s, but got "%s"',
            cpu, gov)

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -393,6 +393,14 @@ function Manager:monitor_worker_stats(id)
                counters.archived[0] = counters.archived[0] + val
                counter.delete(qualified_name)
                S.unlink(strip_suffix(qualified_name, ".counter")..".rrd")
+               local last_in_set = true
+               for _ in pairs(counters.active) do
+                  last_in_set = false
+                  break
+               end
+               if last_in_set then
+                  self:cleanup_aggregated_stats(name, 'counter')
+               end
             end
          elseif has_suffix(ev.name, '.gauge') then
             local gauges = self.gauges[name]
@@ -409,6 +417,14 @@ function Manager:monitor_worker_stats(id)
                gauges.active[pid] = nil
                gauges.rrd[pid] = nil
                S.unlink(strip_suffix(qualified_name, ".gauge")..".rrd")
+               local last_in_set = true
+               for _ in pairs(gauges.active) do
+                  last_in_set = false
+                  break
+               end
+               if last_in_set then
+                  self:cleanup_aggregated_stats(name, 'gauge')
+               end
             end
          end
       end
@@ -441,6 +457,20 @@ function Manager:sample_active_stats()
       end
       fiber_sleep(1)
    end
+end
+
+function Manager:cleanup_aggregated_stats(name, typ)
+   shm.unlink(name)
+   shm.unlink(strip_suffix(name, "."..typ)..".rrd")
+   self:cleanup_parent_directories(name)
+end
+
+function Manager:cleanup_parent_directories(name)
+   local parent = name:match("(.*)/[^/]+$")
+   if not parent then return end
+   for _ in pairs(shm.children(parent)) do return end
+   shm.unlink(parent)
+   self:cleanup_parent_directories(parent)
 end
 
 function Manager:start_worker_for_graph(id, graph)

--- a/src/program/vita/nexthop.lua
+++ b/src/program/vita/nexthop.lua
@@ -176,9 +176,10 @@ function NextHop4:handle_arp (p)
       --        hardware address field of the entry with the new
       --        information in the packet and set Merge_flag to true.
       if ip4eq(arp_ipv4:spa(), self.nexthop_ip4) and self.connected then
+         local diff = not self.eth:dst_eq(arp_ipv4:sha())
          self.eth:dst(arp_ipv4:sha())
          if self.synchronize then self:share_nexthop() end
-         counter.add(self.shm.addresses_updated)
+         if diff then counter.add(self.shm.addresses_updated) end
          self.connected = true
       end
       --    ?Am I the target protocol address?
@@ -447,9 +448,10 @@ function NextHop6:handle_nd (p)
    end
 
    local function add_or_update_nexthop (lladdr)
+      local diff = not self.eth:dst_eq(lladdr)
       self.eth:dst(lladdr)
       if self.synchronize then self:share_nexthop() end
-      if self.connected then counter.add(self.shm.addresses_updated)
+      if self.connected and diff then counter.add(self.shm.addresses_updated)
       else counter.add(self.shm.addresses_added) end
       self.connected = true
    end

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -65,7 +65,8 @@ module vita-esp-gateway {
         ";
       }
       list public-interface4 {
-        uses interface; uses interface4; uses gateway;
+        uses interface; uses interface4; uses overridable-queue; uses gateway;
+        uses nat-ip4;
         key ip; unique queue;
         description "
         Outbound traffic is distributed onto work queues once it is received on
@@ -122,7 +123,8 @@ module vita-esp-gateway {
         ";
       }
       list public-interface6 {
-        uses interface; uses interface6; uses gateway;
+        uses interface; uses interface6; uses overridable-queue; uses gateway;
+        uses nat-ip6;
         key ip; unique queue;
         description "
         Identical to public-interface4 (see above) except that it uses IPv6
@@ -161,6 +163,15 @@ module vita-esp-gateway {
     If a next hop’s MAC address is given Vita will skip ARP or ND look-up and
     address the next hop directly (this option is mainly intended for use in
     testing environments.)
+
+    Public interfaces can have the device-queue option set which overrides
+    automatic device queue selection. Use this option with caution as it can
+    interfere with other users of the device.
+
+    In cases where public interfaces are behind a NAT the nat-ip option must
+    specify the translated network address as seen by its peer gateways. If
+    neither the nat-ip or ip options match the gateway ip as seen by peers
+    key exchange messages will fail to authenticate.
     ";
     choice link {
       case pci { leaf pci { type pci-address; mandatory true; } }
@@ -176,6 +187,15 @@ module vita-esp-gateway {
   grouping interface6 {
     leaf ip { type inet:ipv6-address-no-zone; mandatory true; }
     leaf nexthop-ip { type inet:ipv6-address-no-zone; mandatory true; }
+  }
+  grouping overridable-queue {
+    leaf device-queue { type queue; }
+  }
+  grouping nat-ip4 {
+    leaf nat-ip { type inet:ipv4-address-no-zone; }
+  }
+  grouping nat-ip6 {
+    leaf nat-ip { type inet:ipv6-address-no-zone; }
   }
 
   grouping route {

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -170,12 +170,12 @@ module vita-esp-gateway {
     leaf nexthop-mac { type yang:mac-address; }
   }
   grouping interface4 {
-    leaf ip { type inet:ipv4-address-no-zone; }
-    leaf nexthop-ip { type inet:ipv4-address-no-zone; }
+    leaf ip { type inet:ipv4-address-no-zone; mandatory true; }
+    leaf nexthop-ip { type inet:ipv4-address-no-zone; mandatory true; }
   }
   grouping interface6 {
-    leaf ip { type inet:ipv6-address-no-zone; }
-    leaf nexthop-ip { type inet:ipv6-address-no-zone; }
+    leaf ip { type inet:ipv6-address-no-zone; mandatory true; }
+    leaf nexthop-ip { type inet:ipv6-address-no-zone; mandatory true; }
   }
 
   grouping route {
@@ -214,10 +214,10 @@ module vita-esp-gateway {
     leaf queue { type queue; default 1;}
   }
   grouping gateway4 {
-    leaf ip { type inet:ipv4-address-no-zone; }
+    leaf ip { type inet:ipv4-address-no-zone; mandatory true; }
   }
   grouping gateway6 {
-    leaf ip { type inet:ipv6-address-no-zone; }
+    leaf ip { type inet:ipv6-address-no-zone; mandatory true; }
   }
 
   leaf mtu {
@@ -461,12 +461,12 @@ module vita-esp-gateway {
         description
           "Count of declined or invalid ND solicitations/advertisements.";
       }
-      leaf adresses-added {
+      leaf addresses-added {
         type yang:zero-based-counter64;
         description
           "Count of learned addresses.";
       }
-      leaf adresses-updated {
+      leaf addresses-updated {
         type yang:zero-based-counter64;
         description
           "Count of times an address was updated.";

--- a/src/program/vita/vita-esp-gateway.yang
+++ b/src/program/vita/vita-esp-gateway.yang
@@ -239,7 +239,14 @@ module vita-esp-gateway {
     Confidentiality” (TFC).
     ";
   }
-    
+
+  leaf protocol-port {
+    description "
+    The UDP port used for key exchange protocol messages.
+    ";
+    type inet:port-number;
+    default 303;
+  }
 
   leaf negotiation-ttl {
     description "

--- a/src/program/vita/vita.lua
+++ b/src/program/vita/vita.lua
@@ -45,6 +45,7 @@ local confspec = {
    tfc = {},
    route4 = {default={}},
    route6 = {default={}},
+   protocol_port = {default=default_config.protocol_port},
    negotiation_ttl = {default=default_config.negotation_ttl},
    sa_ttl = {default=default_config.sa_ttl},
    data_plane = {},
@@ -679,7 +680,8 @@ function configure_public_router (conf, append)
    if conf.public_interface4 then
       routes = conf.route4
       config.app(c, "PublicDispatch", dispatch.PublicDispatch, {
-                    node_ip4 = conf.public_interface4.ip
+                    node_ip4 = conf.public_interface4.ip,
+                    protocol_port = conf.protocol_port
       })
       config.app(c, "PublicICMP4", icmp.ICMP4, {
                     node_ip4 = conf.public_interface4.ip
@@ -699,7 +701,8 @@ function configure_public_router (conf, append)
    elseif conf.public_interface6 then
       routes = conf.route6
       config.app(c, "PublicDispatch", dispatch.PublicDispatch, {
-                    node_ip6 = conf.public_interface6.ip
+                    node_ip6 = conf.public_interface6.ip,
+                    protocol_port = conf.protocol_port
       })
       config.app(c, "PublicICMP6", icmp.ICMP6, {
                     node_ip6 = conf.public_interface6.ip
@@ -770,7 +773,8 @@ function configure_exchange (conf, append)
                           (conf.public_interface6 and conf.route6),
                  sa_db_path = queue_sa_db(conf.queue),
                  negotiation_ttl = conf.negotiation_ttl,
-                 sa_ttl = conf.sa_ttl
+                 sa_ttl = conf.sa_ttl,
+                 udp_port = conf.protocol_port
    })
 
    ports.input = "KeyManager.input"


### PR DESCRIPTION
This is a collection of small features, bug fixes, and minor improvements gathered during the development of a demo running Vita in the cloud.

Notable featues:

- 137e2e5ce Long overdue UDP wrapping for AKE protocol
- 30b8da534 Adds a `device-queue` option for public interfaces to override hardware queue selection. This is useful when a, possibly virtualized, interface supports RSS but not a VMDq equivalent (such as EC2 ENA), and lets you allocate e.g. a dedicated public interface with a single device queue for each Vita queue.
- 0b324459e Adds a `nat-ip` option for public interfaces. This option is needed in cases where the public interface address is NATed, because we include the network identity of Vita nodes in the handshake to cryptographically lock down key-exchange intent. In cases where Vita nodes are behind a NAT, the local address would not match the address seen by the remote peer, and cause authentication failures. This new option allows to supply an explicit network identity to override the interface address in the protocol prologue. (NB: this option would be obsoleted by a public key based AKE protocol.)

Minor additions:
- 27eb88d86 Updated default.nix to allow installation of Vita via Nix.
- a0392dc70 Include `snabb rrdcat` in release builds
- 49166417f vita/KeyManager: increase rekey jitter proportional to sa_ttl

Fixes to be upstreamed:
- 0dcefd292 lib.ptree: cleanup obsolete aggregated stats
- 51cab57d5 lib.numa: gracefully handle failure to read CPU performance governor